### PR TITLE
assert失敗した時にテストコードのどこで失敗したかわからなくて悲しい

### DIFF
--- a/JUnit4InstrumentationTestRunner/src/main/java/com/uphyca/testing/AndroidAnnotatedMethodRule.java
+++ b/JUnit4InstrumentationTestRunner/src/main/java/com/uphyca/testing/AndroidAnnotatedMethodRule.java
@@ -91,7 +91,6 @@ class AndroidAnnotatedMethodRule implements TestRule {
                 e.fillInStackTrace();
                 exception = e;
             } catch (Throwable e) {
-                e.fillInStackTrace();
                 exception = e;
             } finally {
                 runCount++;


### PR DESCRIPTION
e.fillInStackTrace() ないほうがよいじゃね？と思ったので、Throwableの時だけとりあえず消しました。
